### PR TITLE
support linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,11 @@ build:
 setup/tools:
 	$(GOINSTALL) github.com/golang/mock/mockgen@v1.5.0
 setup/service:
+ifeq ($(shell uname),Linux)
+	$(DOCKER_COMPOSE_CMD) -f ./docker/docker-compose.yaml -f ./docker/docker-compose.override.yaml up -d
+else
 	$(DOCKER_COMPOSE_CMD) -f ./docker/docker-compose.yaml up -d
+endif
 upgrade-grpc:
 	$(GOGET) -u github.com/swallowarc/tictactoe_battle_proto
 	$(GOMOD) tidy

--- a/docker/docker-compose.override.yaml
+++ b/docker/docker-compose.override.yaml
@@ -1,0 +1,6 @@
+version: "3"
+
+services:
+  envoy:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
# Description
Add docker-compose.override.yaml and fix Makefile for supporting Linux.
The following setting didn't work on Linux:
https://github.com/swallowarc/tictactoe-battle-backend/blob/cb001620a6ae8f80928d8c5d91ec1b2bdb28c570/docker/envoy.yaml#L54

# Required
Docker Engine: ">= 20.10.0"
https://docs.docker.com/engine/release-notes/#networking-3 